### PR TITLE
change generateFilename

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -19,20 +19,19 @@ export default {
     }
   },
 
-  generateFilename(browserName, fullname) {
+generateFilename(browserName, fullname) {
     const timestamp = new Date().toLocaleString('iso', {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
       hour: '2-digit',
+      second:'2-digit',
       minute: '2-digit',
       hour12: false,
     }).replace(/[ ]/g, '--').replace(':', '-');
 
     const filename = encodeURIComponent(
-      `${
-        fullname.replace(/\s+/g, '-')
-      }--${browserName}--${timestamp}`
+      `--${browserName}--${timestamp}`
     ).replace(/%../g, '')
      .replace(/\*/g, '')
      .replace(/\./g, '-')
@@ -40,6 +39,7 @@ export default {
 
     return filename;
   },
+
 
   waitForVideos(videos) {
     const existingVideos = [];

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -58,24 +58,25 @@ describe('Helpers - ', () => {
     });
 
     it('should generate name in form: name--browser--date', () => {
-      expect(helpers.generateFilename(browser, name)).toBe(`${name}--${browser}--${date}`);
+      expect(helpers.generateFilename(browser, name)).toBe(`--${browser}--${date}`);
     });
 
     it('should replace space with -', () => {
       const testname = name + ' space';
-      expect(helpers.generateFilename(browser, testname)).toBe(`${name}-space--${browser}--${date}`);
+      expect(helpers.generateFilename(browser, testname)).toBe(`--${browser}--${date}`);
     });
 
     it('should replace . with -', () => {
       const testname = name + '.dot';
-      expect(helpers.generateFilename(browser, testname)).toBe(`${name}-dot--${browser}--${date}`);
+      expect(helpers.generateFilename(browser, testname)).toBe(`--${browser}--${date}`);
     });
 
     it('should remove characters: /?<>\\/:*|"()[]<>%', () => {
       const testname = name + '-/?<>\\/:*|"()[]<>%comment/';
-      expect(helpers.generateFilename(browser, testname)).toBe(`${name}-comment--${browser}--${date}`);
+      expect(helpers.generateFilename(browser, testname)).toBe(`--${browser}--${date}`);
     });
   });
+
 
 
 


### PR DESCRIPTION
Issue:
https://github.com/presidenten/wdio-video-reporter/issues/1

Changes:
- generateFilename  in helpers.js changes to just contain `browsername-timstampe` (this should be enough to distinguish tests)
- Tests in helpers.spec.js have been changed accordingly.

Tests:
https://travis-ci.org/s-hooshmand/wdio-video-reporter/builds/518875746