### PR TITLE
Fix filenames with single quotes

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,9 +37,8 @@ export default {
         fullname.replace(/\s+/g, '-')
       }--${browserName}--${timestamp}`
     ).replace(/%../g, '')
-     .replace(/\*/g, '')
      .replace(/\./g, '-')
-     .replace(/[\(|\)]/g, '');
+     .replace(/[/\\?%*:'|"<>()]/g, '');
 
     if (filename.length > 250) {
       const truncLength = (250 - 2)/2;

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -75,8 +75,8 @@ describe('Helpers - ', () => {
       expect(helpers.generateFilename(browser, testname)).toBe(`${name}-dot--${browser}--${date}-000`);
     });
 
-    it('should remove characters: /?<>\\/:*|"()[]<>%', () => {
-      const testname = name + '-/?<>\\/:*|"()[]<>%comment/';
+    it('should remove characters: /?<>\\/:*|"()[]\'<>%', () => {
+      const testname = name + '-/?<>\\/:*|"()[]\'<>%comment/';
       expect(helpers.generateFilename(browser, testname)).toBe(`${name}-comment--${browser}--${date}-000`);
     });
 


### PR DESCRIPTION
If there is an `it` that has a single quote(`'`) it will fail to create the .mp4 file because single quotes are not allowed in filenames. This also replaces the other invalid filename characters, encodeURIComponent may or may not already replace some of these. 

BTW.. Nice project! I was able to get everything working very quickly!