### PR TITLE
Check recordingPath is not undefined before removeSync

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ export default class Video extends WdioReporter {
    * Remove empty directories
    */
   onTestSkip () {
-    if(this.recordingPath) {
+    if(this.recordingPath !== undefined) {
       fs.removeSync(this.recordingPath);
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,9 @@ export default class Video extends WdioReporter {
    * Remove empty directories
    */
   onTestSkip () {
-    fs.removeSync(this.recordingPath);
+    if(this.recordingPath) {
+      fs.removeSync(this.recordingPath);
+    }
   }
 
   /**

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -315,6 +315,13 @@ describe('wdio-video-recorder - ', () => {
       video.onTestSkip();
       expect(fsMocks.removeSync).toHaveBeenCalledWith('PATH');
     });
+  
+    it('should not call removeSync if recordingPath is undefined', () => {
+      let video = new Video(options);
+      video.recordingPath = undefined;
+      video.onTestSkip();
+      expect(fsMocks.removeSync).not.toHaveBeenCalled();
+    });
   });
 
   describe('onTestEnd - ', () => {


### PR DESCRIPTION
If tests are skipped and recordingPath is `undefined`, `rimrafSync` don`t allow undefined path and throw these error.

```
[1-0] (node:74467) UnhandledPromiseRejectionWarning: AssertionError [ERR_ASSERTION]: rimraf: missing path
    at Object.rimrafSync (/node_modules/wdio-video-reporter/node_modules/fs-extra/lib/remove/rimraf.js:231:3)
    at Video.onTestSkip (/node_modules/wdio-video-reporter/src/index.js:123:8)
```